### PR TITLE
Introduce auto-generate README.md logic and improve contribution guidelines

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,15 +2,16 @@ name: test
 
 on:
   push:
+    paths:
+      - "generate_readme/**"
   workflow_dispatch:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: check
-        shell: bash
-        run: |
-          ./generate_readme/main.sh
-          git diff --exit-code -- README.md
+      # check only. not commit.
+      - name: Generate README.md
+        run: ./generate_readme/main.sh
+      - run: cat README.md

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -1,0 +1,25 @@
+name: update_readme
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "generate_readme/**"
+      - "!README.md" # Not strictly necessary, but added as a safeguard to prevent accidental infinite loops caused by README.md changes.
+  workflow_dispatch:
+
+jobs:
+  update_readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate README.md
+        run: ./generate_readme/main.sh
+      - name: Commit and push changes
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "github-actions@github.com"
+          git add README.md
+          git commit -m "Auto-update README" || exit 0
+          git push origin main

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -9,6 +9,10 @@ on:
       - "!README.md" # Not strictly necessary, but added as a safeguard to prevent accidental infinite loops caused by README.md changes.
   workflow_dispatch:
 
+concurrency:
+  group: update_readme
+  cancel-in-progress: true
+
 jobs:
   update_readme:
     runs-on: ubuntu-latest

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+oss@liambx.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing
+
+Thank you for your interest in this project!
+
+Please make sure to follow our [Code of Conduct](CODE_OF_CONDUCT.md) in all interactions within this project.
+
+## How to Add an Awesome Item to `README.md`
+
+1. **Modify `generate_readme/data.yaml`**
+   - If you are only adding or editing an item, update `generate_readme/data.yaml` **without** modifying `README.md`.
+   - Commit your changes and push them to a new branch.
+
+2. **Create a Pull Request (PR)**
+   - Once you've pushed your changes, open a PR for review.
+
+## Guidelines
+
+- **Do not manually edit `README.md`**—it is automatically generated.
+- Ensure `generate_readme/data.yaml` follows the correct format.
+  - Comments within `generate_readme/data.yaml` provide guidelines—refer to them as needed.
+- Write clear commit messages and PR descriptions.
+
+## Reference: README.md Auto-Generation Flow
+
+```mermaid
+sequenceDiagram
+    participant Contributor
+    participant Maintainer
+    participant GitHubActions
+
+    Contributor->>Contributor: Edit data.yaml
+    Contributor->>Contributor: Commit & Push (Do not edit README.md)
+    Contributor->>Maintainer: Open a Pull Request (PR)
+
+    Maintainer->>Maintainer: Run ./main.sh to verify changes
+    Maintainer->>Contributor: Request changes? (If needed)
+    Contributor-->>Maintainer: Push updates (if requested)
+
+    Maintainer->>Maintainer: Approve and Merge PR
+
+    Maintainer->>GitHubActions: Update main branch
+    GitHubActions->>GitHubActions: Generate README.md from data.yaml
+    GitHubActions->>GitHubActions: Auto-commit & push updates
+```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- This README.md file is auto-generated. Please refer to `CONTRIBUTING.md` for update instructions. -->
+
 # Awesome ER Diagrams
 
 [![Awesome](_static/awesome.png)](https://github.com/sindresorhus/awesome)

--- a/generate_readme/data.yaml
+++ b/generate_readme/data.yaml
@@ -1,17 +1,34 @@
 ---
-# Headline order
+
+# items_headline_genres.
+#
+# Contributors: If you want to propose a new category, add it to the array below.
 items_headline_genres:
 - "Communication - Social Networks and Forums"
 
-# Items
+
+# items.
+#
+# Contributors: When adding a new item, include the following fields.
+# - title: The project's title (e.g., Mastodon)
+#   repo: The repository URL (e.g., https://github.com/mastodon/mastodon)
+#   liam_erd_web_url: The corresponding Liam ERD page URL
+#     (e.g., https://liambx.com/erd/p/github.com/mastodon/mastodon/blob/main/db/schema.rb?showMode=ALL_FIELDS)
+#   app_description: A brief description of the project.
+#   erd_description: A summary of the entity-relationship diagram (ERD).
+#   headline_genres: The category or categories the project belongs to.
+#     Ensure the values match an entry in `items_headline_genres`.
+#   table_count: The total number of tables in the database.
+#   checked_at: The date when this information was last verified (ISO 8601 format).
+
 items:
-- title: mastodon # title of the project.
+- title: mastodon
   repo: https://github.com/mastodon/mastodon
   liam_erd_web_url: https://liambx.com/erd/p/github.com/mastodon/mastodon/blob/main/db/schema.rb?showMode=ALL_FIELDS
-  app_description: Your self-hosted, globally interconnected microblogging community. # description of the project
-  erd_description: | # erd summary
+  app_description: Your self-hosted, globally interconnected microblogging community.
+  erd_description: |
     This project features a comprehensive schema of tables for managing users, statuses, and media attachments. It accommodates multi-tenant data through tables for users, accounts, templates, and submissions. The schema ensures data integrity through foreign keys and indexes, while providing dedicated support for event tracking, OAuth, file attachments, and webhooks. This demonstrates a robust, form-driven application flow.
   headline_genres:
   - "Communication - Social Networks and Forums"
   table_count: 99
-  checked_at: '2025-02-12' # ISO 8601 Date
+  checked_at: '2025-02-12'

--- a/generate_readme/generate.rb
+++ b/generate_readme/generate.rb
@@ -6,6 +6,8 @@ data = YAML.safe_load(File.read(data_file))
 readme_content = []
 
 readme_content << <<EOF
+<!-- This README.md file is auto-generated. Please refer to `CONTRIBUTING.md` for update instructions. -->
+
 # Awesome ER Diagrams
 
 [![Awesome](_static/awesome.png)](https://github.com/sindresorhus/awesome)


### PR DESCRIPTION
Introduce auto-generate README.md logic and improve contribution guidelines.



* 407471f : Introduced a new workflow `update_readme.yml` to handle automated README updates
    * automatically run `git commit & git push` when main branch is updated.
* 3b4d52f : Add CONTRIBUTING.md and add some comments to data.yaml
    * Add CONTRIBUTING.md. Workflow description is described.
* 1783288 : Add CODE_OF_CONDUCT.md
    *  Same as liam-hq/liam
* 6707897 : Add HTML notice comment to README.md
* 624b548 : Set concurrency
    * for avoiding conflicting

### tested

auto-generating is tested in my fork repo. ✅ 

- https://github.com/hoshinotsuyoshi/awesome-er-diagrams/pull/1
- https://github.com/hoshinotsuyoshi/awesome-er-diagrams/commit/d062c2afb42d6347da8f111f6c27ef19cb6bfc49