### PR TITLE
Add write permissions to README update workflow

### DIFF
--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -13,6 +13,9 @@ concurrency:
   group: update_readme
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
   update_readme:
     runs-on: ubuntu-latest


### PR DESCRIPTION
```
Run git config --global user.name "GitHub Actions"
[main cd1[8](https://github.com/liam-hq/awesome-er-diagrams/actions/runs/13368193915/job/37330622273#step:4:9)d6a] Auto-update README
 1 file changed, 11 insertions(+), 3 deletions(-)
remote: Permission to liam-hq/awesome-er-diagrams.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/liam-hq/awesome-er-diagrams/': The requested URL returned error: 403
Error: Process completed with exit code [12](https://github.com/liam-hq/awesome-er-diagrams/actions/runs/13368193915/job/37330622273#step:4:13)8.
```

ref: https://github.com/liam-hq/awesome-er-diagrams/actions/runs/13368193915/job/37330622273