### PR TITLE
Update GitHub Actions bot identity to official account

### DIFF
--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -26,8 +26,8 @@ jobs:
         run: ./generate_readme/main.sh
       - name: Commit and push changes
         run: |
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "github-actions@github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add README.md
           git commit -m "Auto-update README" || exit 0
           git push origin main


### PR DESCRIPTION
Update the git config in the README update workflow to use the official GitHub Actions identity instead of generic GitHub Actions name/email.
https://stackoverflow.com/questions/76330731/change-display-name-for-github-actions-bot-commit

Once this PR is merged and the README is updated, `github-actions[bot]` will appear in [Contributors](https://github.com/liam-hq/awesome-er-diagrams/graphs/contributors).

`user.name` can be anything. I have somehow chosen to use the same format as dependabot.
ref. https://github.com/masutaka/github-nippou/graphs/contributors

`user.email` can be `github-actions[bot]@users.noreply.github.com`. I made it strict somehow.
