### PR TITLE
Pin third-party GitHub Actions versions with Full Changeset Hash

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# https://docs.github.com/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "10:00"
+      timezone: "Asia/Tokyo"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
       - name: Comment on PR
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1
         with:
           header: preview
           message: |


### PR DESCRIPTION
## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
To mitigate the risk of third-party GitHub Actions being compromised with malware, I are now pinning their versions using Full Changeset Hashes.

Previously, some GitHub Actions were pinned to major versions like v2, allowing for loose version upgrades. With this change, such automatic upgrades will no longer occur. Instead, I will use Dependabot version updates to update them once a month.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->
* We will not pin the versions of official GitHub Actions using Full Changeset Hashes
* This PR does not upgrade any GitHub Actions
    * Using https://github.com/suzuki-shunsuke/pinact
* We will introduce Dependabot version updates to update GitHub Actions once a month

## Additional Notes

> * Using https://github.com/suzuki-shunsuke/pinact

1. Create .pinact.yaml

    ```console
    pinact init
    ```

2. Edit .pinact.yaml

    ```diff
    --- .pinact.yaml.bak	2025-03-17 15:58:00
    +++ .pinact.yaml	2025-03-17 16:03:49
    @@ -5,5 +5,4 @@
       - pattern: "^(.*/)?action\\.ya?ml$"
     
     ignore_actions:
    -# - name: actions/checkout
    -# - name: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml
    +  - name: actions/checkout
    ```

3. Update .github/workflows/*.yml

    ```console
    pinact run
    ```

4. Verify version annotations

    ```console
    pinact run --verify
    ```
