### PR TITLE
pin GitHub Actions to full-length commit SHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       # check only. not commit.
       - name: Generate README.md
         run: ./generate_readme/main.sh

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -21,7 +21,7 @@ jobs:
   update_readme:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Generate README.md
         run: ./generate_readme/main.sh
       - name: Commit and push changes


### PR DESCRIPTION
## Summary
- Pin GitHub Actions references to full-length commit SHAs
- Preparation for enabling Enforce SHA pinning policy as a supply chain attack countermeasure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/liam-hq/awesome-er-diagrams/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
